### PR TITLE
Update std_avg.m

### DIFF
--- a/std_avg.m
+++ b/std_avg.m
@@ -10,7 +10,8 @@ global nraw data_path subject set
    
 disp('ERP Averaging: Working ...')
 
-sfx = '_ebcpyaaM'; %or '_ebcpyaca';  %initialise sfx, please modify it yourself
+sfx = '_ebcpya'; %initialise sfx, please modify it yourself
+% Default eeg not re-referenced: ; if eeg is re-referenced then '_ebcpyaaM' or '_ebcpyaca';  
 
 for s=1:nraw
     sname = [data_path{s} subject{s} sfx set];      


### PR DESCRIPTION
sfx = '_ebcpya'; % Default eeg not re-referenced: ; if eeg is re-referenced then '_ebcpyaaM' or '_ebcpyaca';  %initialise sfx, please modify it yourself

revised sfx to reflect standard stream in which rereference only happens after ERP avg in ERPLab (not on eeg in eeglab)
